### PR TITLE
fix: mariadb: lock to version 10.5

### DIFF
--- a/stack-templates/stack.yml
+++ b/stack-templates/stack.yml
@@ -57,7 +57,7 @@ services:
       - redis
     restart: unless-stopped
   mariadb:
-    image: docker.io/mariadb:10
+    image: docker.io/mariadb:10.5
     environment:
       - TZ=${TIMEZONE}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
This avoids an error where InnoDB will refuse[1] to write to a
compressed page table on initialization.

This appears to be the official solution for Nextcloud[2].

This issue has been circling since the MariadB 10.6.0 release[3],
which changes compressed page tables and makes them not writable by
InnoDB, in preparation for deprecating this feature.

This resolves issue #2[4].

[1]: https://github.com/nextcloud/server/issues/25436
[2]: https://github.com/nextcloud/server/issues/25436#issuecomment-883213001
[3]: https://jira.mariadb.org/browse/MDEV-22367
[4]: https://github.com/LaboratoryB/nextcloud-docker/issues/2